### PR TITLE
[BUG] Media files (audio/video/image) not rendering in Stories, Share…

### DIFF
--- a/src/pages/EditStory.tsx
+++ b/src/pages/EditStory.tsx
@@ -21,6 +21,27 @@ import {
 const db = getFirestore();
 const storage = getStorage();
 
+// Supports both legacy plain-URL strings and new { url, type } objects
+interface MediaItem {
+  url: string;
+  type: string;
+}
+
+// Normalise a media entry to { url, type } regardless of storage format
+function resolveMediaItem(entry: string | MediaItem): MediaItem {
+  if (typeof entry === 'string') {
+    const fileName = decodeURIComponent(entry.split('/o/')[1]?.split('?')[0] ?? '');
+    const ext = fileName.split('.').pop()?.toLowerCase() ?? '';
+    const extToMime: Record<string, string> = {
+      jpg: 'image/jpeg', jpeg: 'image/jpeg', png: 'image/png', gif: 'image/gif', webp: 'image/webp',
+      mp4: 'video/mp4', webm: 'video/webm', ogg: 'video/ogg',
+      mp3: 'audio/mpeg', wav: 'audio/wav',
+    };
+    return { url: entry, type: extToMime[ext] ?? '' };
+  }
+  return entry;
+}
+
 const TAGS = [
   'Workplace Harassment',
   'Domestic Violence',
@@ -42,7 +63,7 @@ export default function EditStory() {
   const [content, setContent] = useState(story?.content || '');
   const [tags, setTags] = useState<string[]>(story?.tags || []);
   const [mediaFiles, setMediaFiles] = useState<FileList | null>(null); // New media files
-  const [existingMediaUrls, setExistingMediaUrls] = useState<string[]>(story?.media_urls || []); // Existing media URLs
+  const [existingMediaUrls, setExistingMediaUrls] = useState<(string | MediaItem)[]>(story?.media_urls || []); // Existing media URLs
   const [loading, setLoading] = useState(false);
 
   // Check authentication
@@ -97,7 +118,7 @@ export default function EditStory() {
       return;
     }
 
-    let updatedMediaUrls = [...existingMediaUrls]; // Start with existing media URLs
+    let updatedMediaUrls: (string | MediaItem)[] = [...existingMediaUrls]; // Start with existing media URLs
 
     try {
       // Upload new media files if any
@@ -116,11 +137,11 @@ export default function EditStory() {
             continue;
           }
 
-          // Upload to Firebase Storage
+          // Upload to Firebase Storage and store MIME type alongside URL
           const storageRef = ref(storage, `story-media/${user.uid}/${story.id}/${Date.now()}-${file.name}`);
           await uploadBytes(storageRef, file);
           const downloadURL = await getDownloadURL(storageRef);
-          updatedMediaUrls.push(downloadURL);
+          updatedMediaUrls.push({ url: downloadURL, type: file.type });
         }
       }
 
@@ -152,25 +173,16 @@ export default function EditStory() {
 
   const handleRemoveMedia = async (url: string) => {
     try {
-      // Extract the path from the Firebase Storage URL
-      const urlPath = url.split('?')[0]; // Remove query parameters
-      const path = urlPath.split('firebase.storage.googleapis.com')[1];
-      
-      if (path) {
-        // Create a reference to the file
-        const fileRef = ref(storage, path);
-        
-        // Delete the file from Firebase Storage
+      const pathMatch = url.match(/o\/(.+)\?/);
+      if (pathMatch && pathMatch[1]) {
+        const path = decodeURIComponent(pathMatch[1]);
         try {
-          await deleteObject(fileRef);
+          await deleteObject(ref(storage, path));
         } catch (deleteError) {
           console.error('Error deleting file from storage:', deleteError);
-          // Continue anyway to update the UI
         }
       }
-      
-      // Update the UI regardless of whether the file was deleted
-      setExistingMediaUrls((prev) => prev.filter((mediaUrl) => mediaUrl !== url));
+      setExistingMediaUrls((prev) => prev.filter((entry) => resolveMediaItem(entry).url !== url));
     } catch (error) {
       console.error('Error processing media URL:', error);
       toast.error('Failed to remove media. Please try again.');
@@ -251,32 +263,38 @@ export default function EditStory() {
               Existing Media
             </label>
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-              {existingMediaUrls.map((url, index) => (
-                <div key={index} className="relative">
-                  {url.match(/\.(jpeg|jpg|gif|png)$/i) && (
-                    <img src={url} alt={`Media ${index + 1}`} className="w-full rounded-md bg-gray-50 dark:bg-gray-700" />
-                  )}
-                  {url.match(/\.(mp4|webm|ogg)$/i) && (
-                    <video controls className="w-full rounded-md bg-black">
-                      <source src={url} type="video/mp4" />
-                      Your browser does not support the video tag.
-                    </video>
-                  )}
-                  {url.match(/\.(mp3|wav|ogg)$/i) && (
-                    <audio controls className="w-full bg-gray-50 dark:bg-gray-700 rounded-md">
-                      <source src={url} type="audio/mpeg" />
-                      Your browser does not support the audio element.
-                    </audio>
-                  )}
-                  <button
-                    type="button"
-                    onClick={() => handleRemoveMedia(url)}
-                    className="absolute top-2 right-2 bg-red-500 text-white rounded-full p-1 hover:bg-red-600 transition-colors"
-                  >
-                    ✕
-                  </button>
-                </div>
-              ))}
+              {existingMediaUrls.map((entry, index) => {
+                const { url, type } = resolveMediaItem(entry);
+                const isImage = type.startsWith('image/');
+                const isVideo = type.startsWith('video/');
+                const isAudio = type.startsWith('audio/');
+                return (
+                  <div key={index} className="relative">
+                    {isImage && (
+                      <img src={url} alt={`Media ${index + 1}`} className="w-full rounded-md bg-gray-50 dark:bg-gray-700" />
+                    )}
+                    {isVideo && (
+                      <video controls className="w-full rounded-md bg-black">
+                        <source src={url} type={type} />
+                        Your browser does not support the video tag.
+                      </video>
+                    )}
+                    {isAudio && (
+                      <audio controls className="w-full bg-gray-50 dark:bg-gray-700 rounded-md">
+                        <source src={url} type={type} />
+                        Your browser does not support the audio element.
+                      </audio>
+                    )}
+                    <button
+                      type="button"
+                      onClick={() => handleRemoveMedia(url)}
+                      className="absolute top-2 right-2 bg-red-500 text-white rounded-full p-1 hover:bg-red-600 transition-colors"
+                    >
+                      ✕
+                    </button>
+                  </div>
+                );
+              })}
             </div>
           </div>
         )}

--- a/src/pages/ShareStory.tsx
+++ b/src/pages/ShareStory.tsx
@@ -68,6 +68,12 @@ const ensureProfileExists = async (user: User) => {
   }
 };
 
+// Supports both legacy plain-URL strings and new { url, type } objects
+interface MediaItem {
+  url: string;
+  type: string;
+}
+
 // Add this interface near the top of your file
 interface Story {
   id: string;
@@ -75,9 +81,24 @@ interface Story {
   content: string;
   tags?: string[];
   author_id: string;
-  media_urls?: string[];
+  media_urls?: (string | MediaItem)[];
   created_at: any; // Or use proper Timestamp type
   reactionsCount?: number;
+}
+
+// Normalise a media entry to { url, type } regardless of storage format
+function resolveMediaItem(entry: string | MediaItem): MediaItem {
+  if (typeof entry === 'string') {
+    const fileName = decodeURIComponent(entry.split('/o/')[1]?.split('?')[0] ?? '');
+    const ext = fileName.split('.').pop()?.toLowerCase() ?? '';
+    const extToMime: Record<string, string> = {
+      jpg: 'image/jpeg', jpeg: 'image/jpeg', png: 'image/png', gif: 'image/gif', webp: 'image/webp',
+      mp4: 'video/mp4', webm: 'video/webm', ogg: 'video/ogg',
+      mp3: 'audio/mpeg', wav: 'audio/wav',
+    };
+    return { url: entry, type: extToMime[ext] ?? '' };
+  }
+  return entry;
 }
 
 export default function ShareStory() {
@@ -365,13 +386,13 @@ export default function ShareStory() {
     let storyText = content;
     // No audio transcription: if no text, storyText remains empty
 
-    let mediaUrls: string[] = [];
+    let mediaUrls: MediaItem[] = [];
     if (mediaFiles && mediaFiles.length > 0) {
       for (const file of mediaFiles) {
         try {
-          // Upload to Firebase Storage
+          // Upload to Firebase Storage and store MIME type alongside URL
           const downloadURL = await uploadMediaFile(file, user.uid);
-          mediaUrls.push(downloadURL);
+          mediaUrls.push({ url: downloadURL, type: file.type });
         } catch (error) {
           console.error('Error uploading media:', error);
           toast.error('Failed to upload media. Please try again.');
@@ -747,12 +768,12 @@ export default function ShareStory() {
 
                   {/* Display media if available */}
                   {story.media_urls && story.media_urls.length > 0 && (
-                    <div className="mt-4 space-y-3 border-t border-gray-200 dark:border-gray-700 pt-4"> {/* Added border-top */}
-                      {story.media_urls.map((url: string, index: number) => {
-                        // ... media rendering logic (same as before) ...
-                        const isImage = url.match(/\.(jpeg|jpg|gif|png)$/i);
-                        const isVideo = url.match(/\.(mp4|webm|ogg)$/i);
-                        const isAudio = url.match(/\.(mp3|wav|ogg)$/i);
+                    <div className="mt-4 space-y-3 border-t border-gray-200 dark:border-gray-700 pt-4">
+                      {story.media_urls.map((entry, index) => {
+                        const { url, type } = resolveMediaItem(entry);
+                        const isImage = type.startsWith('image/');
+                        const isVideo = type.startsWith('video/');
+                        const isAudio = type.startsWith('audio/');
 
                         return (
                           <div key={index} className="relative rounded-md overflow-hidden border border-gray-200 dark:border-gray-600">
@@ -760,21 +781,18 @@ export default function ShareStory() {
                               <img
                                 src={url}
                                 alt={`Media ${index + 1}`}
-                                className="w-full max-h-80 object-contain bg-gray-50 dark:bg-gray-900" // Adjusted max-height
+                                className="w-full max-h-80 object-contain bg-gray-50 dark:bg-gray-900"
                               />
                             )}
                             {isVideo && (
-                              <video
-                                controls
-                                className="w-full max-h-80 object-contain bg-black" // Adjusted max-height
-                              >
-                                <source src={url} type="video/mp4" />
+                              <video controls className="w-full max-h-80 object-contain bg-black">
+                                <source src={url} type={type} />
                                 Your browser does not support the video tag.
                               </video>
                             )}
                             {isAudio && (
                               <audio controls className="w-full p-2 bg-gray-50 dark:bg-gray-700">
-                                <source src={url} type="audio/mpeg" />
+                                <source src={url} type={type} />
                                 Your browser does not support the audio element.
                               </audio>
                             )}

--- a/src/pages/Stories.tsx
+++ b/src/pages/Stories.tsx
@@ -54,17 +54,38 @@ const SUPPORTED_LANGUAGES = [
   // Add more languages as needed
 ];
 
+// Supports both legacy plain-URL strings and new { url, type } objects
+interface MediaItem {
+  url: string;
+  type: string;
+}
+
 // Define the structure of a Story for better type safety
 interface Story {
   id: string;
   title: string;
   content: string;
   tags?: string[];
-  media_urls?: string[];
+  media_urls?: (string | MediaItem)[];
   created_at: any;
   author_id: string;
   reactionsCount: number;
   risk_level?: string;
+}
+
+// Normalise a media entry to { url, type } regardless of storage format
+function resolveMediaItem(entry: string | MediaItem): MediaItem {
+  if (typeof entry === 'string') {
+    const fileName = decodeURIComponent(entry.split('/o/')[1]?.split('?')[0] ?? '');
+    const ext = fileName.split('.').pop()?.toLowerCase() ?? '';
+    const extToMime: Record<string, string> = {
+      jpg: 'image/jpeg', jpeg: 'image/jpeg', png: 'image/png', gif: 'image/gif', webp: 'image/webp',
+      mp4: 'video/mp4', webm: 'video/webm', ogg: 'video/ogg',
+      mp3: 'audio/mpeg', wav: 'audio/wav',
+    };
+    return { url: entry, type: extToMime[ext] ?? '' };
+  }
+  return entry;
 }
 
 
@@ -541,10 +562,11 @@ export default function Stories() {
                     {/* Media Display - only show when expanded */}
                     {isExpanded && story.media_urls && story.media_urls.length > 0 && (
                       <div className="mb-4 space-y-3">
-                        {story.media_urls.map((url: string, index: number) => {
-                          const isImage = url.match(/\.(jpeg|jpg|gif|png)$/i);
-                          const isVideo = url.match(/\.(mp4|webm|ogg)$/i);
-                          const isAudio = url.match(/\.(mp3|wav|ogg)$/i);
+                        {story.media_urls.map((entry, index) => {
+                          const { url, type } = resolveMediaItem(entry);
+                          const isImage = type.startsWith('image/');
+                          const isVideo = type.startsWith('video/');
+                          const isAudio = type.startsWith('audio/');
 
                           return (
                             <div key={index} className="relative rounded-md overflow-hidden border border-gray-200 dark:border-gray-600">
@@ -556,17 +578,14 @@ export default function Stories() {
                                 />
                               )}
                               {isVideo && (
-                                <video
-                                  controls
-                                  className="w-full max-h-64 object-contain bg-black"
-                                >
-                                  <source src={url} type="video/mp4" />
+                                <video controls className="w-full max-h-64 object-contain bg-black">
+                                  <source src={url} type={type} />
                                   Your browser does not support the video tag.
                                 </video>
                               )}
                               {isAudio && (
                                 <audio controls className="w-full p-2 bg-gray-50 dark:bg-gray-700">
-                                  <source src={url} type="audio/mpeg" />
+                                  <source src={url} type={type} />
                                   Your browser does not support the audio element.
                                 </audio>
                               )}


### PR DESCRIPTION
# Description
---

Fixes a critical media rendering bug where uploaded images, videos, and audio files failed to appear across the Stories workflow due to unreliable Firebase URL extension parsing.

This PR replaces fragile URL-based media detection with MIME-type based rendering, ensuring media uploaded through Firebase Storage renders correctly across all affected pages — including browser-recorded voice notes (`audio/webm`).

---
---


# Root Cause
---

The existing implementation attempted to determine media type by running regex checks directly against Firebase Storage download URLs:

```ts
const isImage = url.match(/\.(jpeg|jpg|gif|png)$/i);
const isVideo = url.match(/\.(mp4|webm|ogg)$/i);
const isAudio = url.match(/\.(mp3|wav|ogg)$/i);
```

This fails because Firebase download URLs append query parameters:

```txt
https://firebasestorage.googleapis.com/v0/b/project.appspot.com/o/story-media%2Fuid%2F1234-voice-recording.webm?alt=media&token=abc123
```

As a result:

* regex checks returned `null`
* no media component rendered
* uploaded media silently disappeared from the UI

Additionally:

* `webm` was missing from the audio regex
* browser-recorded voice notes (`audio/webm`) could never render correctly

---
---

# Before vs After
---


| Scenario                       | Before             | After                    |
| ------------------------------ | ------------------ | ------------------------ |
| Uploaded image                 | ❌ Blank media area | ✅ Renders correctly      |
| Uploaded video                 | ❌ No video player  | ✅ Video playback works   |
| Voice recording (`audio/webm`) | ❌ Never rendered   | ✅ Audio controls visible |
| Firebase URL with query params | ❌ Regex failure    | ✅ Works reliably         |
| Edit Story media preview       | ❌ Missing preview  | ✅ Existing media visible |

---
---

# Testing Done
---

✅ Uploaded PNG/JPG images render correctly across all affected pages

✅ Uploaded MP4/WebM videos render with playback controls

✅ Browser-recorded voice notes (`audio/webm`) now render correctly

✅ Existing Firebase Storage URLs with query params work properly

✅ Media previews render correctly in Edit Story flow

✅ No regressions to story creation or upload workflow

---
---

# Acceptance Criteria — Completed
---

* [x] Images render correctly in Stories, ShareStory, and EditStory
* [x] Videos render correctly with playback controls
* [x] Voice recordings render correctly using `<audio>` controls
* [x] Browser-recorded `audio/webm` files are supported
* [x] Media detection no longer depends on Firebase URL suffixes
* [x] Fix applied consistently across all affected files
* [x] Existing uploads continue working without regressions

---

# Contribution Interest

Hiii @Piyushydv08 , i've implemented the issue i proposed
do review it and feel free to merge the PR
fixes issue #139

