### PR TITLE
Feat: Add Copy Story Button for Easy Content Sharing (#168)

### DIFF
--- a/src/pages/ShareStory.tsx
+++ b/src/pages/ShareStory.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { toast } from 'react-hot-toast';
 import { auth } from '../lib/firebase';
-import { Edit, Trash2, CheckSquare, Loader2, Sparkles } from 'lucide-react';
+import { Edit, Trash2, CheckSquare, Loader2, Sparkles, Copy } from 'lucide-react';
 import { User } from 'firebase/auth';
 
 // Firebase imports
@@ -368,6 +368,19 @@ export default function ShareStory() {
         }
       }
     });
+  };
+
+  const handleCopyStory = async (text: string) => {
+    if (!navigator.clipboard) {
+      toast.error('Clipboard API not available');
+      return;
+    }
+    try {
+      await navigator.clipboard.writeText(text);
+      toast.success('Story copied to clipboard!');
+    } catch (err) {
+      toast.error('Failed to copy story.');
+    }
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -850,7 +863,15 @@ export default function ShareStory() {
                       <span>Reactions: {story.reactionsCount}</span>
                     </div>
                     {/* Action Buttons */}
-                    <div className="flex items-center space-x-3"> {/* Adjusted spacing */}
+                    <div className="flex flex-wrap items-center gap-3">
+                      {/* Copy Button */}
+                      <button
+                        onClick={() => handleCopyStory(displayContent)}
+                        className="inline-flex items-center text-teal-600 hover:text-teal-800 dark:text-teal-400 dark:hover:text-teal-300"
+                        title="Copy Story"
+                      >
+                        <Copy size={16} className="mr-1" /> Copy
+                      </button>
                       {/* Grammar Fix Button (for existing stories) */}
                       <button
                         onClick={() => handleGrammarFix(story.id, story.content)}


### PR DESCRIPTION
# 🏷️ PR Type

* [x] ✨ Feature

## 🔗 Related Issue

Closes #168

---

## 📝 Rationale / Motivation

Currently, users can view, edit, delete, and fix grammar for their stories, but there is no quick way to copy story content for reuse, sharing, or backup purposes.

This enhancement adds a Copy Story button that allows users to instantly copy story content to their clipboard with a single click.

---

## ✨ Description of Changes

### Frontend

* Added a Copy button alongside existing story action buttons
* Added Clipboard API integration using `navigator.clipboard.writeText()`
* Added success toast notification when content is copied successfully
* Added error toast notification when copy fails
* Added Clipboard API availability check
* Improved responsive layout by replacing `space-x-3` with `flex-wrap gap-3` to prevent overflow on smaller screens

### Files Modified

* `src/pages/ShareStory.tsx`

---

## 🧪 Testing Instructions

1. Login and navigate to the Share Story page.
2. Scroll to the "Your Stories" section.
3. Click the Copy button on any story.
4. Verify that a success toast appears.
5. Paste the copied content into a text editor using Ctrl + V.
6. Verify the story content is copied correctly.
7. Test on smaller screen sizes and ensure action buttons wrap correctly.

---

## 👀 Impact Assessment

* Improves user experience and accessibility
* No backend changes
* No database schema changes
* No breaking changes
* Mobile responsive

---

## 🖼️ Screenshots
<img width="1913" height="965" alt="Screenshot 2026-06-05 210232" src="https://github.com/user-attachments/assets/b9949ca7-d1e2-4264-83d7-ddf870d287db" />
<img width="1917" height="967" alt="Screenshot 2026-06-05 210237" src="https://github.com/user-attachments/assets/ba4c1709-6fe6-4d6d-a73a-c3f55daa5bad" />


---

## ⚡ Checklist

* [x] Code follows project guidelines
* [x] Changes tested locally
* [x] Related issue linked
* [x] User-facing changes documented
* [x] No new warnings/errors introduced
* [x] Production build passes successfully
